### PR TITLE
Product and test bug fixes on stack.Push

### DIFF
--- a/bst/bst.go
+++ b/bst/bst.go
@@ -53,12 +53,18 @@ func insert(n *node, k int, v interface{}) (r *node, added bool) {
 // Delete removes a given key from the tree and returns true if it was removed.
 // Average: O(log(n)) Worst: O(n)
 func (t *T) Delete(k int) (deleted bool) {
-	_, deleted = delete(t.root, k)
+	n, deleted := delete(t.root, k)
 	if deleted {
+
+		// Handling the case of root deletion.
+		if t.root.key == k {
+			t.root = n
+		}
+
 		t.count--
 	}
 
-	return
+	return deleted
 }
 
 // delete recursively deletes a key from the tree.
@@ -78,7 +84,8 @@ func delete(n *node, k int) (r *node, deleted bool) {
 			for s.r != nil {
 				s = s.r
 			}
-			r = s
+			r.key = s.key
+			r.val = s.val
 			r.l, deleted = delete(s, s.key)
 		} else if n.l != nil {
 			r = n.l

--- a/bst/bst.go
+++ b/bst/bst.go
@@ -55,7 +55,6 @@ func insert(n *node, k int, v interface{}) (r *node, added bool) {
 func (t *T) Delete(k int) (deleted bool) {
 	n, deleted := delete(t.root, k)
 	if deleted {
-
 		// Handling the case of root deletion.
 		if t.root.key == k {
 			t.root = n

--- a/bst/bst_test.go
+++ b/bst/bst_test.go
@@ -35,6 +35,71 @@ func TestInsert(t *testing.T) {
 	}
 }
 
+func TestRemove_SingleElement(t *testing.T) {
+	bst := new(T)
+
+	bst.Insert(5, 10)
+
+	if !bst.Delete(5) {
+		t.Errorf("Element %v should have been removed", 5)
+	}
+
+	if bst.Find(5) != nil {
+		t.Errorf("Element %v should not have been found", 5)
+	}
+}
+
+func TestRemove_RootWithSingleChild(t *testing.T) {
+	bst := new(T)
+
+	bst.Insert(5, 10)
+	bst.Insert(4, 8)
+
+	if !bst.Delete(5) {
+		t.Errorf("Element %v should have been removed", 5)
+	}
+
+	if bst.Find(5) != nil {
+		t.Errorf("Element %v should not have been found", 5)
+	}
+
+	if bst.Find(4) == nil {
+		t.Errorf("Element with key %v was not found", 4)
+	}
+
+	if bst.count != 1 {
+		t.Errorf("Expected element count %v found cound %v", 1, bst.count)
+	}
+}
+
+func TestRemove_RootWithTwoChildren(t *testing.T) {
+	bst := new(T)
+
+	bst.Insert(5, 10)
+	bst.Insert(4, 8)
+	bst.Insert(6, 12)
+
+	if !bst.Delete(5) {
+		t.Errorf("Element %v should have been removed", 5)
+	}
+
+	if bst.Find(5) != nil {
+		t.Errorf("Element %v should not have been found", 5)
+	}
+
+	if bst.Find(4) == nil {
+		t.Errorf("Element with key %v was not found", 4)
+	}
+
+	if bst.Find(6) == nil {
+		t.Errorf("Element with key %v was not found", 6)
+	}
+
+	if bst.count != 2 {
+		t.Errorf("Expected element count %v found cound %v", 1, bst.count)
+	}
+}
+
 func TestRemove(t *testing.T) {
 	expected := []int{5, 3, 7, 4, 6}
 	bst := new(T)

--- a/stack/stack.go
+++ b/stack/stack.go
@@ -26,7 +26,7 @@ func (s *S) Init(size int) {
 func (s *S) Push(v interface{}) {
 	// dynamically increase the size of storage as needed
 	if s.i+1 == cap(s.storage) {
-		ns := make([]interface{}, s.i*2)
+		ns := make([]interface{}, cap(s.storage)*2)
 		copy(ns, s.storage)
 		s.storage = ns
 	}

--- a/stack/stack_test.go
+++ b/stack/stack_test.go
@@ -12,7 +12,24 @@ func TestPushPop(t *testing.T) {
 		s.Push(i)
 	}
 
-	for i := iterations - 1; i <= 0; i-- {
+	for i := iterations - 1; i >= 0; i-- {
+		testPop(t, s, i)
+	}
+}
+
+func TestInitPushSmallestStack(t *testing.T) {
+	// Arrange.
+	s := new(S)
+	
+	// Act.
+	s.Init(1)
+
+	for i := 0; i < 4; i++ {
+		s.Push(i)
+	}
+
+	// Assert.
+	for i := 3; i >= 0; i-- {
 		testPop(t, s, i)
 	}
 }


### PR DESCRIPTION
1. Fix for bug: Push fails when stack is initialized with '1'.
2. Test to validate fix above.
3. For for test bug: Wrong pop iteration boundary.
